### PR TITLE
Parameterized paths

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/JohnSundell/Files.git",
         "state": {
           "branch": null,
-          "revision": "92b57bea0e737e7d92b5ff281f46ec2b59faf91c",
-          "version": "3.1.0"
+          "revision": "22fe84797d499ffca911ccd896b34efaf06a50b9",
+          "version": "4.1.1"
         }
       },
       {
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "Shell",
-        "repositoryURL": "https://github.com/tuist/Shell",
-        "state": {
-          "branch": null,
-          "revision": "d38121f89401db902b0d0bfc30b987e2c84c254e",
-          "version": "2.0.3"
-        }
-      },
-      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
-          "revision": "d3d54ce662dfee7fef619330b71d251b8d4869f9",
-          "version": "2.2.0"
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
         }
       },
       {
@@ -51,8 +42,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "f717bbce0e19f0129fc001b2b6bed43b70fd8b87",
+          "version": "0.9.1"
         }
       },
       {
@@ -60,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "f6ac7b8118ff5d1bc0faee7f37bf6f8fd8f95602",
-          "version": "0.0.1"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {
@@ -69,8 +60,17 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "300c3a1b468bd413a15e1f63b196dc6113bc62fb",
-          "version": "7.0.1"
+          "revision": "81bb2bb333eafa68f8ecd8187a4bb56d51e78e97",
+          "version": "7.14.0"
+        }
+      },
+      {
+        "package": "XcodeProjCExt",
+        "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
+        "state": {
+          "branch": null,
+          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
+          "version": "0.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,10 @@ let package = Package(
         .library(name: "Carting", targets: ["CartingCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/JohnSundell/Files.git", from: "3.0.0"),
-        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "7.0.0"))
+        .package(url: "https://github.com/JohnSundell/Files.git", from: "4.1.1"),
+        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.3.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMajor(from: "7.14.0"))
     ],
     targets: [
         .target(name: "Carting", dependencies: ["CartingCore", "ArgumentParser"]),

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -13,11 +13,11 @@ struct Info: ParsableCommand {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Argument(help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPaths: [String]
+    @Option(name: [.short, .long], default: "Carthage", help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPath: String
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: path, frameworksDirectoryPaths: frameworksDirectoryPaths)
-        try projectService.printFrameworksInformation()
+        let projectService = ProjectService(projectDirectoryPath: path)
+        try projectService.printFrameworksInformation(frameworksDirectoryPath: frameworksDirectoryPath)
     }
 }

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -10,11 +10,11 @@ struct Info: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(abstract: "Prints Carthage frameworks list with linking description.")
 
-    @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
-    var path: String?
+    @Option(name: [.short, .long], help: "The project directory path.")
+    var path: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
 
-    @Option(name: [.short, .long], default: "Carthage", help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPath: String
+    @Option(name: [.short, .long], help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPath: String = "Carthage"
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: path)

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -14,10 +14,10 @@ struct Info: ParsableCommand {
     var path: String = PathDispatcher.defaultProjectDirectoryPath
 
     @Argument(help: "The project directory that contains frameworks to proceed")
-    var frameworksDirectoryPath: String = PathDispatcher.defaultFrameworksDirectory
+    var frameworksDirectoryName: String = PathDispatcher.defaultFrameworksDirectory
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: path)
-        try projectService.printFrameworksInformation(frameworksDirectoryPath: frameworksDirectoryPath)
+        try projectService.printFrameworksInformation(frameworksDirectoryName: frameworksDirectoryName)
     }
 }

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -13,8 +13,13 @@ struct Info: ParsableCommand {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
+    @Option(name: [.short, .long],
+            default: "Carthage",
+            help: "The project directory that contains frameworks to proceed.")
+    var frameworksDirectoryPath: String
+
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: path)
+        let projectService = try ProjectService(projectDirectoryPath: path, frameworksDirectoryPath: frameworksDirectoryPath)
         try projectService.printFrameworksInformation()
     }
 }

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -13,13 +13,11 @@ struct Info: ParsableCommand {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Option(name: [.short, .long],
-            default: "Carthage",
-            help: "The project directory that contains frameworks to proceed.")
-    var frameworksDirectoryPath: String
+    @Argument(help: nil)
+    var frameworksDirectoryPaths: [String]
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: path, frameworksDirectoryPath: frameworksDirectoryPath)
+        let projectService = try ProjectService(projectDirectoryPath: path, frameworksDirectoryPaths: frameworksDirectoryPaths)
         try projectService.printFrameworksInformation()
     }
 }

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -11,10 +11,10 @@ struct Info: ParsableCommand {
     static let configuration: CommandConfiguration = .init(abstract: "Prints Carthage frameworks list with linking description.")
 
     @Option(name: [.short, .long], help: "The project directory path.")
-    var path: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
+    var path: String = PathDispatcher.defaultProjectDirectoryPath
 
-    @Option(name: [.short, .long], help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPath: String = "Carthage"
+    @Argument(help: "The project directory that contains frameworks to proceed")
+    var frameworksDirectoryPath: String = PathDispatcher.defaultFrameworksDirectory
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: path)

--- a/Sources/Carting/Commands/Info.swift
+++ b/Sources/Carting/Commands/Info.swift
@@ -13,7 +13,7 @@ struct Info: ParsableCommand {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Argument(help: nil)
+    @Argument(help: "The project directories that contains frameworks to proceed")
     var frameworksDirectoryPaths: [String]
 
     func run() throws {

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -15,7 +15,7 @@ struct Lint: ParsableCommand {
 
     func run() throws {
         let projectService = try ProjectService(projectDirectoryPath: options.path,
-                                                frameworksDirectoryPath: options.frameworksDirectoryPath)
+                                                frameworksDirectoryPaths: options.frameworksDirectoryPaths)
         try projectService.lintScript(withName: options.script,
                                       format: options.format,
                                       targetName: options.target,

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -16,18 +16,18 @@ struct Lint: ParsableCommand {
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
         if !options.projectNames.isEmpty,
-           let frameworksDirectoryPath = options.frameworksDirectoryPaths.first {
+           let frameworksDirectoryName = options.frameworksDirectoryNames.first {
             try projectService.lintScript(withName: options.script,
                                           format: options.format,
                                           targetName: options.target,
                                           projectNames: options.projectNames,
-                                          frameworksDirectoryPath: frameworksDirectoryPath)
+                                          frameworksDirectoryName: frameworksDirectoryName)
         }
         else {
             try projectService.lintScript(withName: options.script,
                                           format: options.format,
                                           targetName: options.target,
-                                          frameworksDirectoryPaths: options.frameworksDirectoryPaths)
+                                          frameworksDirectoryNames: options.frameworksDirectoryNames)
         }
     }
 }

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -14,11 +14,11 @@ struct Lint: ParsableCommand {
     var options: Options
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: options.path,
-                                                frameworksDirectoryPaths: options.frameworksDirectoryPaths)
+        let projectService = ProjectService(projectDirectoryPath: options.path)
         try projectService.lintScript(withName: options.script,
                                       format: options.format,
                                       targetName: options.target,
-                                      projectNames: options.projectNames)
+                                      projectNames: options.projectNames,
+                                      frameworksDirectoryPath: options.frameworksDirectoryPath)
     }
 }

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -15,10 +15,19 @@ struct Lint: ParsableCommand {
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
-        try projectService.lintScript(withName: options.script,
-                                      format: options.format,
-                                      targetName: options.target,
-                                      projectNames: options.projectNames,
-                                      frameworksDirectoryPath: options.frameworksDirectoryPath)
+        if !options.projectNames.isEmpty,
+           let frameworksDirectoryPath = options.frameworksDirectoryPaths.first {
+            try projectService.lintScript(withName: options.script,
+                                          format: options.format,
+                                          targetName: options.target,
+                                          projectNames: options.projectNames,
+                                          frameworksDirectoryPath: frameworksDirectoryPath)
+        }
+        else {
+            try projectService.lintScript(withName: options.script,
+                                          format: options.format,
+                                          targetName: options.target,
+                                          frameworksDirectoryPaths: options.frameworksDirectoryPaths)
+        }
     }
 }

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -15,19 +15,6 @@ struct Lint: ParsableCommand {
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
-        if !options.projectNames.isEmpty,
-           let frameworksDirectoryName = options.frameworksDirectoryNames.first {
-            try projectService.lintScript(withName: options.script,
-                                          format: options.format,
-                                          targetName: options.target,
-                                          projectNames: options.projectNames,
-                                          frameworksDirectoryName: frameworksDirectoryName)
-        }
-        else {
-            try projectService.lintScript(withName: options.script,
-                                          format: options.format,
-                                          targetName: options.target,
-                                          frameworksDirectoryNames: options.frameworksDirectoryNames)
-        }
+        try projectService.updateScript(with: options.projectServiceContext)
     }
 }

--- a/Sources/Carting/Commands/Lint.swift
+++ b/Sources/Carting/Commands/Lint.swift
@@ -14,7 +14,8 @@ struct Lint: ParsableCommand {
     var options: Options
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: options.path)
+        let projectService = try ProjectService(projectDirectoryPath: options.path,
+                                                frameworksDirectoryPath: options.frameworksDirectoryPath)
         try projectService.lintScript(withName: options.script,
                                       format: options.format,
                                       targetName: options.target,

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -14,8 +14,8 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Argument(help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPaths: [String]
+    @Option(name: [.short, .long], default: "Carthage", help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPath: String
 
     @Option(name: [.short, .long],
             default: .list,

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -14,15 +14,15 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], help: "The project directory path.")
     var path: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
 
-    @Option(name: [.short, .long], help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPath: String = "Carthage"
-
     @Option(name: [.short, .long], help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
     var format: Format = .list
 
     @Option(name: [.short, .long], help: "The project target name.")
     var target: String = ProcessInfo.processInfo.environment["TARGET_NAME", default: ""]
 
-    @Argument(help: "The names of projects.")
-    var projectNames: [String]
+    @Option(help: "The names of projects. If specified, only first (or default) frameworksDirectoryPath will be proceed")
+    var projectNames: [String] = []
+
+    @Argument(help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPaths: [String] = ["Carthage"]
 }

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -14,7 +14,12 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Option(name: [.short, .long], default: .list, help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
+    @Option(name: [.short, .long], default: "Carthage", help: "The project directory that contains frameworks to proceed.")
+    var frameworksDirectoryPath: String
+
+    @Option(name: [.short, .long],
+            default: .list,
+            help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
     var format: Format
 
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["TARGET_NAME"], help: "The project target name.")

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -12,7 +12,7 @@ struct Options: ParsableArguments {
     var script: String = "Carthage"
 
     @Option(name: [.short, .long], help: "The project directory path.")
-    var path: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
+    var path: String = PathDispatcher.defaultProjectDirectoryPath
 
     @Option(name: [.short, .long], help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
     var format: Format = .list
@@ -24,5 +24,5 @@ struct Options: ParsableArguments {
     var projectNames: [String] = []
 
     @Argument(help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPaths: [String] = ["Carthage"]
+    var frameworksDirectoryPaths: [String] = [PathDispatcher.defaultFrameworksDirectory]
 }

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -25,4 +25,13 @@ struct Options: ParsableArguments {
 
     @Argument(help: "The project directories that contains frameworks to proceed")
     var frameworksDirectoryNames: [String] = [PathDispatcher.defaultFrameworksDirectory]
+
+    var projectServiceContext: ProjectService.Context {
+        .init(scriptName: script,
+              projectPath: path,
+              format: format,
+              target: target,
+              projectNames: projectNames,
+              frameworksDirectoryNames: frameworksDirectoryNames)
+    }
 }

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -20,9 +20,9 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], help: "The project target name.")
     var target: String = ProcessInfo.processInfo.environment["TARGET_NAME", default: ""]
 
-    @Option(help: "The names of projects. If specified, only first (or default) frameworksDirectoryPath will be proceed")
+    @Option(help: "The names of projects. If specified, only first (or default) frameworksDirectoryName will be proceed")
     var projectNames: [String] = []
 
     @Argument(help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPaths: [String] = [PathDispatcher.defaultFrameworksDirectory]
+    var frameworksDirectoryNames: [String] = [PathDispatcher.defaultFrameworksDirectory]
 }

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -14,8 +14,8 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Option(name: [.short, .long], default: "Carthage", help: "The project directory that contains frameworks to proceed.")
-    var frameworksDirectoryPath: String
+    @Argument(help: nil)
+    var frameworksDirectoryPaths: [String] = ["Carthage"]
 
     @Option(name: [.short, .long],
             default: .list,

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -23,6 +23,6 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], help: "The project target name.")
     var target: String = ProcessInfo.processInfo.environment["TARGET_NAME", default: ""]
 
-    @Option(name: [.customShort("n"), .long], help: "The names of projects.")
+    @Argument(help: "The names of projects.")
     var projectNames: [String]
 }

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -8,22 +8,20 @@ import ArgumentParser
 
 struct Options: ParsableArguments {
 
-    @Option(name: [.short, .long], default: "Carthage", help: "The name of Carthage script.")
-    var script: String
+    @Option(name: [.short, .long], help: "The name of Carthage script.")
+    var script: String = "Carthage"
 
-    @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
-    var path: String?
+    @Option(name: [.short, .long], help: "The project directory path.")
+    var path: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
 
-    @Option(name: [.short, .long], default: "Carthage", help: "The project directories that contains frameworks to proceed")
-    var frameworksDirectoryPath: String
+    @Option(name: [.short, .long], help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPath: String = "Carthage"
 
-    @Option(name: [.short, .long],
-            default: .list,
-            help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
-    var format: Format
+    @Option(name: [.short, .long], help: "Format of input/output file paths: file - using simple paths, list - using xcfilelists")
+    var format: Format = .list
 
-    @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["TARGET_NAME"], help: "The project target name.")
-    var target: String?
+    @Option(name: [.short, .long], help: "The project target name.")
+    var target: String = ProcessInfo.processInfo.environment["TARGET_NAME", default: ""]
 
     @Option(name: [.customShort("n"), .long], help: "The names of projects.")
     var projectNames: [String]

--- a/Sources/Carting/Commands/Options.swift
+++ b/Sources/Carting/Commands/Options.swift
@@ -14,8 +14,8 @@ struct Options: ParsableArguments {
     @Option(name: [.short, .long], default: ProcessInfo.processInfo.environment["PROJECT_DIR"], help: "The project directory path.")
     var path: String?
 
-    @Argument(help: nil)
-    var frameworksDirectoryPaths: [String] = ["Carthage"]
+    @Argument(help: "The project directories that contains frameworks to proceed")
+    var frameworksDirectoryPaths: [String]
 
     @Option(name: [.short, .long],
             default: .list,

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -13,7 +13,7 @@ struct Update: ParsableCommand {
     @OptionGroup()
     var options: Options
 
-    @Flag(name: [.customLong("append-to-file"), .short], help: "Should output be appended to previous output")
+    @Flag(name: [.customLong("append-to-file"), .short], help: "Specify if output should be appended to previous output")
     var isAppendingToFile: Bool = false
 
     func run() throws {

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -16,18 +16,18 @@ struct Update: ParsableCommand {
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
         if !options.projectNames.isEmpty,
-           let frameworksDirectoryPath = options.frameworksDirectoryPaths.first {
+           let frameworksDirectoryName = options.frameworksDirectoryNames.first {
             try projectService.updateScript(withName: options.script,
                                             format: options.format,
                                             targetName: options.target,
                                             projectNames: options.projectNames,
-                                            frameworksDirectoryPath: frameworksDirectoryPath)
+                                            frameworksDirectoryName: frameworksDirectoryName)
         }
         else {
             try projectService.updateScript(withName: options.script,
                                             format: options.format,
                                             targetName: options.target,
-                                            frameworksDirectoryPaths: options.frameworksDirectoryPaths)
+                                            frameworksDirectoryNames: options.frameworksDirectoryNames)
         }
     }
 }

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -14,7 +14,7 @@ struct Update: ParsableCommand {
     var options: Options
 
     @Flag(name: [.customLong("append to file"), .short], help: "Should output be appended to previous output")
-    var isAppendingToFile: Bool
+    var isAppendingToFile: Bool = false
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -13,16 +13,26 @@ struct Update: ParsableCommand {
     @OptionGroup()
     var options: Options
 
-    @Flag(name: [.customLong("append to file"), .short], help: "Should output be appended to previous output")
+    @Flag(name: [.customLong("append-to-file"), .short], help: "Should output be appended to previous output")
     var isAppendingToFile: Bool = false
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
-        try projectService.updateScript(withName: options.script,
-                                        format: options.format,
-                                        targetName: options.target,
-                                        projectNames: options.projectNames,
-                                        frameworksDirectoryPath: options.frameworksDirectoryPath,
-                                        shouldAppend: isAppendingToFile)
+        if !options.projectNames.isEmpty,
+           let frameworksDirectoryPath = options.frameworksDirectoryPaths.first {
+            try projectService.updateScript(withName: options.script,
+                                            format: options.format,
+                                            targetName: options.target,
+                                            projectNames: options.projectNames,
+                                            frameworksDirectoryPath: frameworksDirectoryPath,
+                                            shouldAppend: isAppendingToFile)
+        }
+        else {
+            try projectService.updateScript(withName: options.script,
+                                            format: options.format,
+                                            targetName: options.target,
+                                            frameworksDirectoryPaths: options.frameworksDirectoryPaths,
+                                            shouldAppend: isAppendingToFile)
+        }
     }
 }

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -15,19 +15,6 @@ struct Update: ParsableCommand {
 
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
-        if !options.projectNames.isEmpty,
-           let frameworksDirectoryName = options.frameworksDirectoryNames.first {
-            try projectService.updateScript(withName: options.script,
-                                            format: options.format,
-                                            targetName: options.target,
-                                            projectNames: options.projectNames,
-                                            frameworksDirectoryName: frameworksDirectoryName)
-        }
-        else {
-            try projectService.updateScript(withName: options.script,
-                                            format: options.format,
-                                            targetName: options.target,
-                                            frameworksDirectoryNames: options.frameworksDirectoryNames)
-        }
+        try projectService.updateScript(with: options.projectServiceContext)
     }
 }

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -13,12 +13,16 @@ struct Update: ParsableCommand {
     @OptionGroup()
     var options: Options
 
+    @Flag(name: [.customLong("append to file"), .short], help: "Should output be appended to previous output")
+    var isAppendingToFile: Bool
+
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
         try projectService.updateScript(withName: options.script,
                                         format: options.format,
                                         targetName: options.target,
                                         projectNames: options.projectNames,
-                                        frameworksDirectoryPath: options.frameworksDirectoryPath)
+                                        frameworksDirectoryPath: options.frameworksDirectoryPath,
+                                        shouldAppend: isAppendingToFile)
     }
 }

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -14,7 +14,8 @@ struct Update: ParsableCommand {
     var options: Options
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: options.path)
+        let projectService = try ProjectService(projectDirectoryPath: options.path,
+                                                frameworksDirectoryPath: options.frameworksDirectoryPath)
         try projectService.updateScript(withName: options.script,
                                         format: options.format,
                                         targetName: options.target,

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -14,11 +14,11 @@ struct Update: ParsableCommand {
     var options: Options
 
     func run() throws {
-        let projectService = try ProjectService(projectDirectoryPath: options.path,
-                                                frameworksDirectoryPaths: options.frameworksDirectoryPaths)
+        let projectService = ProjectService(projectDirectoryPath: options.path)
         try projectService.updateScript(withName: options.script,
                                         format: options.format,
                                         targetName: options.target,
-                                        projectNames: options.projectNames)
+                                        projectNames: options.projectNames,
+                                        frameworksDirectoryPath: options.frameworksDirectoryPath)
     }
 }

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -15,7 +15,7 @@ struct Update: ParsableCommand {
 
     func run() throws {
         let projectService = try ProjectService(projectDirectoryPath: options.path,
-                                                frameworksDirectoryPath: options.frameworksDirectoryPath)
+                                                frameworksDirectoryPaths: options.frameworksDirectoryPaths)
         try projectService.updateScript(withName: options.script,
                                         format: options.format,
                                         targetName: options.target,

--- a/Sources/Carting/Commands/Update.swift
+++ b/Sources/Carting/Commands/Update.swift
@@ -13,9 +13,6 @@ struct Update: ParsableCommand {
     @OptionGroup()
     var options: Options
 
-    @Flag(name: [.customLong("append-to-file"), .short], help: "Specify if output should be appended to previous output")
-    var isAppendingToFile: Bool = false
-
     func run() throws {
         let projectService = ProjectService(projectDirectoryPath: options.path)
         if !options.projectNames.isEmpty,
@@ -24,15 +21,13 @@ struct Update: ParsableCommand {
                                             format: options.format,
                                             targetName: options.target,
                                             projectNames: options.projectNames,
-                                            frameworksDirectoryPath: frameworksDirectoryPath,
-                                            shouldAppend: isAppendingToFile)
+                                            frameworksDirectoryPath: frameworksDirectoryPath)
         }
         else {
             try projectService.updateScript(withName: options.script,
                                             format: options.format,
                                             targetName: options.target,
-                                            frameworksDirectoryPaths: options.frameworksDirectoryPaths,
-                                            shouldAppend: isAppendingToFile)
+                                            frameworksDirectoryPaths: options.frameworksDirectoryPaths)
         }
     }
 }

--- a/Sources/CartingCore/Extensions/Collection+KeyPath.swift
+++ b/Sources/CartingCore/Extensions/Collection+KeyPath.swift
@@ -1,0 +1,163 @@
+//
+//  Copyright © 2018 Rosberry. All rights reserved.
+//
+
+public extension Collection {
+
+    /// Returns collection of values at keyPaths of contained elements.
+    func map<T: Equatable>(by keyPath: KeyPath<Element, T>) -> [T] {
+        self.map { innerElement -> T in
+            innerElement[keyPath: keyPath]
+        }
+    }
+
+    /// Returns collection of elements that are having value at certain keypath equal to value at keypath of passed element.
+    func filter<T: Equatable>(by keyPath: KeyPath<Element, T>, of element: Element) -> [Element] {
+        filter { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == element[keyPath: keyPath]
+        }
+    }
+
+    /// Returns collection of elements that are having specific value at certain keypath.
+    func filter<T: Equatable>(by value: T, at keyPath: KeyPath<Element, T>) -> [Element] {
+        filter { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Returns collection of elements that has value at certain keypath that satisfies the given predicate.
+    func filter<T: Equatable>(by keyPath: KeyPath<Element, T>, isIncluded: (T) -> Bool) -> [Element] {
+        filter { innerElement -> Bool in
+            isIncluded(innerElement[keyPath: keyPath])
+        }
+    }
+
+    /// Returns first element in the collection that has value at certain keypath equal to value at keypath of passed element.
+    func first<T: Equatable>(by keyPath: KeyPath<Element, T>, of element: Element) -> Element? {
+        first { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == element[keyPath: keyPath]
+        }
+    }
+
+    /// Returns first element in the collection that has specific value at certain keypath.
+    func first<T: Equatable>(with value: T, at keyPath: KeyPath<Element, T>) -> Element? {
+        first { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Returns first element in the collection that has specific value at certain keypath.
+    func first<T: Equatable>(with value: T?, at keyPath: KeyPath<Element, T>) -> Element? {
+        first { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Checks if collection contains element that has value at certain keypath equal to value at keypath of passed element.
+    func contains<T: Equatable>(by keyPath: KeyPath<Element, T>, of element: Element) -> Bool {
+        contains { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == element[keyPath: keyPath]
+        }
+    }
+
+    /// Checks if collection contains element that has specific value at certain keypath.
+    func contains<T: Equatable>(with value: T, at keyPath: KeyPath<Element, T>) -> Bool {
+        contains { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Returns index of element in the collection that has value at certain keypath equal to value at keypath of passed element.
+    func index<T: Equatable>(by keyPath: KeyPath<Element, T>, of element: Element) -> Index? {
+        firstIndex { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == element[keyPath: keyPath]
+        }
+    }
+
+    /// Returns index of element in the collection that has specific value at certain keypath.
+    func index<T: Equatable>(with value: T, at keyPath: KeyPath<Element, T>) -> Index? {
+        firstIndex { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Returns the minimum element in the collection, using the given keyPath to get comparable property.
+    func min<T: Comparable>(by keyPath: KeyPath<Element, T>) -> Element? {
+        self.min { first, second -> Bool in
+            first[keyPath: keyPath] < second[keyPath: keyPath]
+        }
+    }
+
+    /// Returns the maximum element in the collection, using the given keyPath to get comparable property.
+    func max<T: Comparable>(by keyPath: KeyPath<Element, T>) -> Element? {
+        self.max { first, second -> Bool in
+            first[keyPath: keyPath] < second[keyPath: keyPath]
+        }
+    }
+
+    /// Returns the value of minimum element in the collection, using the given keyPath to get comparable property
+    func mapMin<T: Comparable>(by keyPath: KeyPath<Element, T>) -> T? {
+        let min = self.min(by: keyPath)
+        return min?[keyPath: keyPath]
+    }
+
+    /// Returns the value of maximum element in the collection, using the given keyPath to get comparable property
+    func mapMax<T: Comparable>(by keyPath: KeyPath<Element, T>) -> T? {
+        let max = self.max(by: keyPath)
+        return max?[keyPath: keyPath]
+    }
+
+    /// Returns collection of values at keyPaths of contained elements.
+    func compactMap<T>(by keyPath: KeyPath<Element, T?>) -> [T] {
+        compactMap { innerElement -> T? in
+            innerElement[keyPath: keyPath]
+        }
+    }
+
+    /// Checks if all collection elements has specific value at certain keypath.
+    func isAll<T: Equatable>(with value: T, at keyPath: KeyPath<Element, T>) -> Bool {
+        allSatisfy { innerElement -> Bool in
+            innerElement[keyPath: keyPath] == value
+        }
+    }
+
+    /// Returns sorted collection by comparator, using the given keyPath to get comparable property
+    func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>, using comparator: (T, T) -> Bool = { f, s in f < s }) -> [Element] {
+        sorted { first, second in
+            comparator(first[keyPath: keyPath], second[keyPath: keyPath])
+        }
+    }
+
+    /// Returns sorted collection by comparator, using the given keyPath to get comparable property
+    func sorted<T: Comparable>(by keyPath: KeyPath<Element, T?>,
+                               defaultValue: T,
+                               using comparator: (T, T) -> Bool = { f, s in f < s }) -> [Element] {
+        sorted { first, second in
+            comparator((first[keyPath: keyPath] ?? defaultValue), (second[keyPath: keyPath] ?? defaultValue))
+        }
+    }
+}
+
+public extension MutableCollection where Self: RandomAccessCollection {
+    /// Sort the collection by comparator, using the given keyPath to get comparable property
+    mutating func sort<T: Comparable>(by keyPath: KeyPath<Element, T>, using comparator: (T, T) -> Bool = { f, s in f < s }) {
+        sort { first, second in
+            comparator(first[keyPath: keyPath], second[keyPath: keyPath])
+        }
+    }
+
+    /// Sort the collection by comparator, using the given keyPath to get comparable property
+    mutating func sort<T: Comparable>(by keyPath: KeyPath<Element, T?>,
+                                      defaultValue: T,
+                                      using comparator: (T, T) -> Bool = { f, s in f < s }) {
+        sort { first, second in
+            comparator((first[keyPath: keyPath] ?? defaultValue), (second[keyPath: keyPath] ?? defaultValue))
+        }
+    }
+}
+
+public extension Sequence where Element: Sequence {
+    func flatten() -> [Element.Element] {
+        reduce([Element.Element](), +)
+    }
+}

--- a/Sources/CartingCore/Extensions/Dictionary+Helpers.swift
+++ b/Sources/CartingCore/Extensions/Dictionary+Helpers.swift
@@ -1,0 +1,12 @@
+//
+//
+
+import Foundation
+
+extension Dictionary {
+    @inlinable public func mapKeys<T: Hashable>(_ transform: (Key) throws -> T) rethrows -> [T: Value] {
+        [T: Value](uniqueKeysWithValues: try map { key, value -> (T, Value) in
+            (try transform(key), value)
+        })
+    }
+}

--- a/Sources/CartingCore/Extensions/PBXBuildPhase+App.swift
+++ b/Sources/CartingCore/Extensions/PBXBuildPhase+App.swift
@@ -1,0 +1,10 @@
+//
+//
+
+import XcodeProj
+
+public extension PBXBuildPhase {
+    var name: String? {
+        name()
+    }
+}

--- a/Sources/CartingCore/Extensions/PBXNativeTarget+Frameworks.swift
+++ b/Sources/CartingCore/Extensions/PBXNativeTarget+Frameworks.swift
@@ -21,10 +21,15 @@ extension PBXNativeTarget {
     }
 
     func paths(for frameworks: [Framework], type: PathType) -> [String] {
-        let linkedCarthageDynamicFrameworkNames = linkedFrameworks(withNames: frameworks.map(\.name))
+        paths(for: [type: frameworks])
+    }
 
-        return linkedCarthageDynamicFrameworkNames.map { frameworkName in
-            return type.prefix + frameworkName
+    func paths(for frameworks: [PathType: [Framework]]) -> [String] {
+        frameworks.reduce([]) { result, value in
+            let (type, frameworks) = value
+            return result + linkedFrameworks(withNames: frameworks.map(\.name)).map { name in
+                type.prefix + name
+            }
         }
     }
 }

--- a/Sources/CartingCore/Extensions/PBXNativeTarget+Frameworks.swift
+++ b/Sources/CartingCore/Extensions/PBXNativeTarget+Frameworks.swift
@@ -6,28 +6,25 @@ import XcodeProj
 
 extension PBXNativeTarget {
 
-    func linkedFrameworks(for context: (PathType, [Framework])) -> [String] {
+    func linkedFrameworks(withNames names: [String]) -> [String] {
         guard let frameworksBuildPhase = try? frameworksBuildPhase() else {
             return []
         }
-        let (type, frameworks) = context
-        return frameworks.compactMap { framework in
-            let name = framework.name
-            guard let files = frameworksBuildPhase.files,
-                  files.contains(with: name, at: \.file?.name) else {
-                return nil
+        return names.filter { name in
+            guard let files = frameworksBuildPhase.files else {
+                return false
             }
-            return type.prefix + name
+            return files.contains { file in
+                file.file?.name == name
+            }
         }
     }
 
     func paths(for frameworks: [Framework], type: PathType) -> [String] {
-        paths(for: [type: frameworks])
-    }
+        let linkedCarthageDynamicFrameworkNames = linkedFrameworks(withNames: frameworks.map(\.name))
 
-    func paths(for frameworks: [PathType: [Framework]]) -> [String] {
-        frameworks.reduce([]) { result, value in
-            result + linkedFrameworks(for: value)
+        return linkedCarthageDynamicFrameworkNames.map { frameworkName in
+            type.prefix + frameworkName
         }
     }
 }

--- a/Sources/CartingCore/Extensions/URL+String.swift
+++ b/Sources/CartingCore/Extensions/URL+String.swift
@@ -1,0 +1,4 @@
+//
+//
+
+import Foundation

--- a/Sources/CartingCore/Extensions/URL+String.swift
+++ b/Sources/CartingCore/Extensions/URL+String.swift
@@ -1,4 +1,0 @@
-//
-//
-
-import Foundation

--- a/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
+++ b/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
@@ -7,7 +7,7 @@ import XcodeProj
 extension XcodeProj {
 
     func targets(with type: PBXProductType, name: String) -> [PBXNativeTarget] {
-        return pbxproj.nativeTargets
+        pbxproj.nativeTargets
             .filter { target in
                 guard target.productType == type else {
                     return false

--- a/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
+++ b/Sources/CartingCore/Extensions/XcodeProj+Targets.swift
@@ -6,13 +6,13 @@ import XcodeProj
 
 extension XcodeProj {
 
-    func targets(with type: PBXProductType, name: String?) -> [PBXNativeTarget] {
+    func targets(with type: PBXProductType, name: String) -> [PBXNativeTarget] {
         return pbxproj.nativeTargets
             .filter { target in
                 guard target.productType == type else {
                     return false
                 }
-                if let name = name {
+                if !name.isEmpty {
                     return target.name.lowercased() == name.lowercased()
                 }
                 return true

--- a/Sources/CartingCore/Services/Framework.swift
+++ b/Sources/CartingCore/Services/Framework.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2019 Artem Novichkov. All rights reserved.
 //
 
-struct Framework {
+struct Framework: Hashable {
 
     enum Architecture: String {
         case i386, x86_64, armv7, arm64 //swiftlint:disable:this identifier_name

--- a/Sources/CartingCore/Services/PathDispatcher.swift
+++ b/Sources/CartingCore/Services/PathDispatcher.swift
@@ -9,6 +9,7 @@ public enum PathDispatcher {
     public static let carthageScriptPath: String = "/usr/local/bin/carthage"
     public static let defaultFrameworksDirectory: String = "Carthage"
     public static let defaultProjectDirectoryPath: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
+    public static let listsFolderName: String = "xcfilelists"
 
     public static func iOSFrameworksDirectory(path: String) -> String {
         "\(path)/Build/iOS"

--- a/Sources/CartingCore/Services/PathDispatcher.swift
+++ b/Sources/CartingCore/Services/PathDispatcher.swift
@@ -1,0 +1,16 @@
+//
+//
+
+import Foundation
+
+public enum PathDispatcher {
+    public static let srcRoot: String = "$(SRCROOT)/"
+    public static let projectExtension: String = "xcodeproj"
+    public static let carthageScriptPath: String = "/usr/local/bin/carthage"
+    public static let defaultFrameworksDirectory: String = "Carthage"
+    public static let defaultProjectDirectoryPath: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
+
+    public static func iOSFrameworksDirectory(path: String) -> String {
+        "\(path)/Build/iOS"
+    }
+}

--- a/Sources/CartingCore/Services/PathDispatcher.swift
+++ b/Sources/CartingCore/Services/PathDispatcher.swift
@@ -11,7 +11,7 @@ public enum PathDispatcher {
     public static let defaultProjectDirectoryPath: String = ProcessInfo.processInfo.environment["PROJECT_DIR", default: ""]
     public static let listsFolderName: String = "xcfilelists"
 
-    public static func iOSFrameworksDirectory(path: String) -> String {
-        "\(path)/Build/iOS"
+    public static func iOSFrameworksDirectory(name: String) -> String {
+        "\(name)/Build/iOS"
     }
 }

--- a/Sources/CartingCore/Services/PathType.swift
+++ b/Sources/CartingCore/Services/PathType.swift
@@ -3,12 +3,12 @@
 //
 
 enum PathType {
-    case input, output
+    case input(frameworksDirectoryPath: String), output
 
     var prefix: String {
         switch self {
-        case .input:
-            return "$(SRCROOT)/Carthage/Build/iOS/"
+        case let .input(frameworksDirectoryPath):
+            return "$(SRCROOT)/\(frameworksDirectoryPath)/Build/iOS/"
         case .output:
             return "$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/"
         }

--- a/Sources/CartingCore/Services/PathType.swift
+++ b/Sources/CartingCore/Services/PathType.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2019 Artem Novichkov. All rights reserved.
 //
 
-enum PathType {
+enum PathType: Hashable {
     case input(frameworksDirectoryPath: String), output
 
     var prefix: String {

--- a/Sources/CartingCore/Services/PathType.swift
+++ b/Sources/CartingCore/Services/PathType.swift
@@ -8,7 +8,7 @@ enum PathType: Hashable {
     var prefix: String {
         switch self {
         case let .input(frameworksDirectoryPath):
-            return "$(SRCROOT)/\(frameworksDirectoryPath)/Build/iOS/"
+            return PathDispatcher.iOSFrameworksDirectory(path: "\(PathDispatcher.srcRoot)\(frameworksDirectoryPath)")
         case .output:
             return "$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/"
         }

--- a/Sources/CartingCore/Services/PathType.swift
+++ b/Sources/CartingCore/Services/PathType.swift
@@ -3,12 +3,12 @@
 //
 
 enum PathType: Hashable {
-    case input(frameworksDirectoryPath: String), output
+    case input(frameworksDirectoryName: String), output
 
     var prefix: String {
         switch self {
-        case let .input(frameworksDirectoryPath):
-            return PathDispatcher.iOSFrameworksDirectory(path: "\(PathDispatcher.srcRoot)\(frameworksDirectoryPath)")
+        case let .input(frameworksDirectoryName):
+            return PathDispatcher.iOSFrameworksDirectory(name: "\(PathDispatcher.srcRoot)\(frameworksDirectoryName)") + "/"
         case .output:
             return "$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/"
         }

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -36,6 +36,23 @@ public final class ProjectService {
         self.projectDirectoryPath = projectDirectoryPath
     }
 
+    public func updateScript(with context: Context) throws {
+        if !context.projectNames.isEmpty,
+           let frameworksDirectoryName = context.frameworksDirectoryNames.first {
+            try updateScript(withName: context.scriptName,
+                             format: context.format,
+                             targetName: context.target,
+                             projectNames: context.projectNames,
+                             frameworksDirectoryName: frameworksDirectoryName)
+        }
+        else {
+            try updateScript(withName: context.scriptName,
+                             format: context.format,
+                             targetName: context.target,
+                             frameworksDirectoryNames: context.frameworksDirectoryNames)
+        }
+    }
+
     public func updateScript(withName scriptName: String,
                              format: Format,
                              targetName: String,
@@ -77,11 +94,11 @@ public final class ProjectService {
     }
 
     private func updateScript(withName scriptName: String,
-                             format: Format,
-                             targetName: String,
-                             projectPath: String,
-                             frameworksDirectoryName: String,
-                             shouldAppend: Bool) throws {
+                              format: Format,
+                              targetName: String,
+                              projectPath: String,
+                              frameworksDirectoryName: String,
+                              shouldAppend: Bool) throws {
         func updateBuildPhaseForFile(_ buildPhase: PBXShellScriptBuildPhase?,
                                      in target: PBXNativeTarget,
                                      inputPaths: [String],
@@ -199,6 +216,23 @@ public final class ProjectService {
         }
     }
 
+    public func lintScript(with context: Context) throws {
+        if !context.projectNames.isEmpty,
+           let frameworksDirectoryName = context.frameworksDirectoryNames.first {
+            try projectService.lintScript(withName: context.script,
+                                          format: context.format,
+                                          targetName: context.target,
+                                          projectNames: context.projectNames,
+                                          frameworksDirectoryName: frameworksDirectoryName)
+        }
+        else {
+            try projectService.lintScript(withName: context.script,
+                                          format: context.format,
+                                          targetName: context.target,
+                                          frameworksDirectoryNames: context.frameworksDirectoryNames)
+        }
+    }
+
     public func lintScript(withName scriptName: String,
                            format: Format,
                            targetName: String,
@@ -237,10 +271,10 @@ public final class ProjectService {
     }
 
     private func lintScript(withName scriptName: String,
-                           format: Format,
-                           targetName: String,
-                           projectPath: String,
-                           frameworksDirectoryName: String) throws {
+                            format: Format,
+                            targetName: String,
+                            projectPath: String,
+                            frameworksDirectoryName: String) throws {
 
         func missingPaths(for target: PBXNativeTarget,
                           buildPhase: PBXShellScriptBuildPhase,

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -35,7 +35,7 @@ public final class ProjectService {
 
     public init(projectDirectoryPath: String?, frameworksDirectoryPaths: [String]) throws {
         self.projectDirectoryPath = projectDirectoryPath
-        self.frameworksDirectoryPaths = frameworksDirectoryPaths
+        self.frameworksDirectoryPaths = frameworksDirectoryPaths.isEmpty ? ["Carthage"] : frameworksDirectoryPaths
     }
 
     public func updateScript(withName scriptName: String, format: Format, targetName: String?, projectNames: [String]) throws {

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -83,13 +83,6 @@ public final class ProjectService {
                              projectPath: String,
                              frameworksDirectoryPath: String,
                              shouldAppend: Bool) throws {
-        let (xcodeproj, filteredTargets, dynamicFrameworks) = try initialContext(projectPath: projectPath,
-                                                                                 targetName: targetName,
-                                                                                 frameworksDirectoryPath: frameworksDirectoryPath)
-
-        var needUpdateProject = false
-        var filelistsWereUpdated = false
-
         func updateBuildPhaseForFile(_ buildPhase: PBXShellScriptBuildPhase?,
                                      in target: PBXNativeTarget,
                                      inputPaths: [String],
@@ -177,6 +170,13 @@ public final class ProjectService {
                 print("✅ Script \(scriptName) in target \(target.name) was successfully updated.")
             }
         }
+
+        let (xcodeproj, filteredTargets, dynamicFrameworks) = try initialContext(projectPath: projectPath,
+                                                                                 targetName: targetName,
+                                                                                 frameworksDirectoryPath: frameworksDirectoryPath)
+
+        var needUpdateProject = false
+        var filelistsWereUpdated = false
 
         try filteredTargets.forEach { target in
             try proceed(target: target)

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -63,10 +63,9 @@ public final class ProjectService {
 
         let carthageDynamicFrameworks = try dynamicFrameworksInformation().mapKeys(PathType.input)
 
-        try filteredTargets
-                .forEach { target in
+        try filteredTargets.forEach { target in
             let inputPaths = target.paths(for: carthageDynamicFrameworks)
-            let outputPaths = target.paths(for: carthageDynamicFrameworks.values.reduce([], +), type: .output)
+            let outputPaths = target.paths(for: carthageDynamicFrameworks.values.flatten(), type: .output)
 
             let targetBuildPhase = target.buildPhases.first { $0.name() == scriptName }
             let projectBuildPhase = xcodeproj.pbxproj.shellScriptBuildPhases.first { $0.uuid == targetBuildPhase?.uuid }
@@ -141,8 +140,7 @@ public final class ProjectService {
     }
 
     public func printFrameworksInformation() throws {
-        let informations = try frameworksInformation()
-        informations.values.reduce([], +).forEach { information in
+        (try frameworksInformation()).values.flatten().forEach { information in
             let description = [information.name, information.linking.rawValue].joined(separator: "\t\t") +
                               "\t" +
                               information.architectures.map(\.rawValue).joined(separator: ", ")
@@ -172,14 +170,13 @@ public final class ProjectService {
 
         let carthageDynamicFrameworks = try dynamicFrameworksInformation().mapKeys(PathType.input)
 
-        try filteredTargets
-                .forEach { target in
+        try filteredTargets.forEach { target in
 
             let inputPaths = target.paths(for: carthageDynamicFrameworks)
-            let outputPaths = target.paths(for: carthageDynamicFrameworks.values.reduce([], +), type: .output)
+            let outputPaths = target.paths(for: carthageDynamicFrameworks.values.flatten(), type: .output)
 
-            let targetBuildPhase = target.buildPhases.first { $0.name() == scriptName }
-            let buildPhase = xcodeproj.pbxproj.shellScriptBuildPhases.first { $0.uuid == targetBuildPhase?.uuid }
+            let targetBuildPhase = target.buildPhases.first(with: scriptName, at: \.name)
+            let buildPhase = xcodeproj.pbxproj.shellScriptBuildPhases.first(with: targetBuildPhase?.uuid, at: \.uuid)
 
             guard let projectBuildPhase = buildPhase else {
                 return

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -27,7 +27,7 @@ public final class ProjectService {
         if let path = projectDirectoryPath, let folder = try? Folder(path: path) {
             return folder
         }
-        return FileSystem().currentFolder
+        return Folder.current
     }
 
     // MARK: - Lifecycle
@@ -326,7 +326,7 @@ public final class ProjectService {
     }
 
     private func frameworksInformation(frameworksDirectoryPath: String) throws -> [Framework] {
-        let frameworkFolder = try projectFolder.subfolder(atPath: "\(frameworksDirectoryPath)/Build/iOS")
+        let frameworkFolder = try projectFolder.subfolder(at: "\(frameworksDirectoryPath)/Build/iOS")
         let frameworks = frameworkFolder.subfolders.filter { $0.name.hasSuffix("framework") }
         return try frameworks.map(information)
     }
@@ -355,7 +355,7 @@ public final class ProjectService {
             let (oldContent, newContent) = try self.content(for: file, newContent: content, shouldAppend: shouldAppend)
             if oldContent != newContent {
                 try shellOut(to: "chmod +w \"\(file.name)\"", at: folder.path)
-                try file.write(string: newContent)
+                try file.write(newContent)
                 fileWereUpdated = true
                 print("✅ \(file.name) was successfully updated")
                 try shellOut(to: "chmod -w \"\(file.name)\"", at: folder.path)
@@ -363,7 +363,7 @@ public final class ProjectService {
         }
         else {
             let file = try folder.createFile(named: name)
-            try file.write(string: content)
+            try file.write(content)
             fileWereUpdated = true
             print("✅ \(file.name) was successfully added")
             try shellOut(to: "chmod -w \"\(file.name)\"", at: folder.path)

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -40,7 +40,7 @@ public final class ProjectService {
                              format: Format,
                              targetName: String,
                              projectNames: [String],
-                             frameworksDirectoryPath: String) throws {
+                             frameworksDirectoryName: String) throws {
         let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: projectNames)
         guard projectPaths.count > 0 else {
             print(Constants.nothingToUpdate)
@@ -51,7 +51,7 @@ public final class ProjectService {
                              format: format,
                              targetName: targetName,
                              projectPath: path,
-                             frameworksDirectoryPath: frameworksDirectoryPath,
+                             frameworksDirectoryName: frameworksDirectoryName,
                              shouldAppend: false)
         }
     }
@@ -59,19 +59,19 @@ public final class ProjectService {
     public func updateScript(withName scriptName: String,
                              format: Format,
                              targetName: String,
-                             frameworksDirectoryPaths: [String]) throws {
+                             frameworksDirectoryNames: [String]) throws {
         let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: [])
         guard let projectPath = projectPaths.first else {
             print(Constants.nothingToUpdate)
             return
         }
         try removeListsDirectory()
-        for path in frameworksDirectoryPaths {
+        for path in frameworksDirectoryNames {
             try updateScript(withName: scriptName,
                              format: format,
                              targetName: targetName,
                              projectPath: projectPath,
-                             frameworksDirectoryPath: path,
+                             frameworksDirectoryName: path,
                              shouldAppend: true)
         }
     }
@@ -80,7 +80,7 @@ public final class ProjectService {
                              format: Format,
                              targetName: String,
                              projectPath: String,
-                             frameworksDirectoryPath: String,
+                             frameworksDirectoryName: String,
                              shouldAppend: Bool) throws {
         func updateBuildPhaseForFile(_ buildPhase: PBXShellScriptBuildPhase?,
                                      in target: PBXNativeTarget,
@@ -124,7 +124,7 @@ public final class ProjectService {
         }
 
         func proceed(target: PBXNativeTarget) throws {
-            let (inputPaths, outputPaths) = paths(in: target, at: frameworksDirectoryPath, frameworks: dynamicFrameworks)
+            let (inputPaths, outputPaths) = paths(in: target, at: frameworksDirectoryName, frameworks: dynamicFrameworks)
             let targetBuildPhase = target.buildPhases.first(with: scriptName, at: \.name)
             let projectBuildPhase = xcodeproj.pbxproj.shellScriptBuildPhases.first { $0.uuid == targetBuildPhase?.uuid }
 
@@ -172,7 +172,7 @@ public final class ProjectService {
 
         let (xcodeproj, filteredTargets, dynamicFrameworks) = try initialContext(projectPath: projectPath,
                                                                                  targetName: targetName,
-                                                                                 frameworksDirectoryPath: frameworksDirectoryPath)
+                                                                                 frameworksDirectoryName: frameworksDirectoryName)
 
         var needUpdateProject = false
         var filelistsWereUpdated = false
@@ -189,8 +189,8 @@ public final class ProjectService {
         }
     }
 
-    public func printFrameworksInformation(frameworksDirectoryPath: String) throws {
-        let informations = try frameworksInformation(frameworksDirectoryPath: frameworksDirectoryPath)
+    public func printFrameworksInformation(frameworksDirectoryName: String) throws {
+        let informations = try frameworksInformation(frameworksDirectoryName: frameworksDirectoryName)
         informations.forEach { information in
             let description = [information.name, information.linking.rawValue].joined(separator: "\t\t") +
                               "\t" +
@@ -203,7 +203,7 @@ public final class ProjectService {
                            format: Format,
                            targetName: String,
                            projectNames: [String],
-                           frameworksDirectoryPath: String) throws {
+                           frameworksDirectoryName: String) throws {
         let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: projectNames)
         guard projectPaths.count > 0 else {
             print(Constants.nothingToLint)
@@ -214,25 +214,25 @@ public final class ProjectService {
                            format: format,
                            targetName: targetName,
                            projectPath: path,
-                           frameworksDirectoryPath: frameworksDirectoryPath)
+                           frameworksDirectoryName: frameworksDirectoryName)
         }
     }
 
     public func lintScript(withName scriptName: String,
                            format: Format,
                            targetName: String,
-                           frameworksDirectoryPaths: [String]) throws {
+                           frameworksDirectoryNames: [String]) throws {
         let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: [])
         guard let projectPath = projectPaths.first else {
             print(Constants.nothingToLint)
             return
         }
-        for path in frameworksDirectoryPaths {
+        for path in frameworksDirectoryNames {
             try lintScript(withName: scriptName,
                            format: format,
                            targetName: targetName,
                            projectPath: projectPath,
-                           frameworksDirectoryPath: path)
+                           frameworksDirectoryName: path)
         }
     }
 
@@ -240,7 +240,7 @@ public final class ProjectService {
                            format: Format,
                            targetName: String,
                            projectPath: String,
-                           frameworksDirectoryPath: String) throws {
+                           frameworksDirectoryName: String) throws {
 
         func missingPaths(for target: PBXNativeTarget,
                           buildPhase: PBXShellScriptBuildPhase,
@@ -293,7 +293,7 @@ public final class ProjectService {
                 return
             }
 
-            let (inputPaths, outputPaths) = paths(in: target, at: frameworksDirectoryPath, frameworks: frameworks)
+            let (inputPaths, outputPaths) = paths(in: target, at: frameworksDirectoryName, frameworks: frameworks)
             for path in (try missingPaths(for: target, buildPhase: buildPhase, inputPaths: inputPaths, outputPaths: outputPaths)) {
                 print("error: Missing \(path) in \(target.name) target")
             }
@@ -301,7 +301,7 @@ public final class ProjectService {
 
         let (xcodeproj, filteredTargets, dynamicFrameworks) = try initialContext(projectPath: projectPath,
                                                                                  targetName: targetName,
-                                                                                 frameworksDirectoryPath: frameworksDirectoryPath)
+                                                                                 frameworksDirectoryName: frameworksDirectoryName)
 
         try filteredTargets.forEach { target in
             try proceed(target: target, frameworks: dynamicFrameworks)
@@ -316,7 +316,7 @@ public final class ProjectService {
 
     private func initialContext(projectPath: String,
                                 targetName: String,
-                                frameworksDirectoryPath: String) throws -> (XcodeProj, [PBXNativeTarget], [Framework]) {
+                                frameworksDirectoryName: String) throws -> (XcodeProj, [PBXNativeTarget], [Framework]) {
         let xcodeproj = try XcodeProj(pathString: projectPath)
 
         let filteredTargets = try targets(in: xcodeproj, withName: targetName)
@@ -325,15 +325,15 @@ public final class ProjectService {
             throw Error.noTargets(name: targetName)
         }
 
-        let dynamicFrameworks = try dynamicFrameworksInformation(frameworksDirectoryPath: frameworksDirectoryPath)
+        let dynamicFrameworks = try dynamicFrameworksInformation(frameworksDirectoryName: frameworksDirectoryName)
 
         return (xcodeproj, filteredTargets, dynamicFrameworks)
     }
 
     private func paths(in target: PBXNativeTarget,
-                       at frameworksDirectoryPath: String,
+                       at frameworksDirectoryName: String,
                        frameworks: [Framework]) -> (input: [String], output: [String]) {
-        (target.paths(for: frameworks, type: .input(frameworksDirectoryPath: frameworksDirectoryPath)),
+        (target.paths(for: frameworks, type: .input(frameworksDirectoryName: frameworksDirectoryName)),
          target.paths(for: frameworks, type: .output))
     }
 
@@ -377,14 +377,14 @@ public final class ProjectService {
         }
     }
 
-    private func frameworksInformation(frameworksDirectoryPath: String) throws -> [Framework] {
-        let frameworkFolder = try projectFolder.subfolder(at: PathDispatcher.iOSFrameworksDirectory(path: frameworksDirectoryPath))
+    private func frameworksInformation(frameworksDirectoryName: String) throws -> [Framework] {
+        let frameworkFolder = try projectFolder.subfolder(at: PathDispatcher.iOSFrameworksDirectory(name: frameworksDirectoryName))
         let frameworks = frameworkFolder.subfolders.filter { $0.name.hasSuffix("framework") }
         return try frameworks.map(information)
     }
 
-    private func dynamicFrameworksInformation(frameworksDirectoryPath: String) throws -> [Framework] {
-        try frameworksInformation(frameworksDirectoryPath: frameworksDirectoryPath).filter { information in
+    private func dynamicFrameworksInformation(frameworksDirectoryName: String) throws -> [Framework] {
+        try frameworksInformation(frameworksDirectoryName: frameworksDirectoryName).filter { information in
             information.linking == .dynamic
         }
     }

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -21,10 +21,10 @@ public final class ProjectService {
         static let nothingToUpdate = "🤷‍♂️ Nothing to update."
     }
 
-    private let projectDirectoryPath: String?
+    private let projectDirectoryPath: String
 
     private var projectFolder: Folder {
-        if let path = projectDirectoryPath, let folder = try? Folder(path: path) {
+        if !projectDirectoryPath.isEmpty, let folder = try? Folder(path: projectDirectoryPath) {
             return folder
         }
         return Folder.current
@@ -32,13 +32,13 @@ public final class ProjectService {
 
     // MARK: - Lifecycle
 
-    public init(projectDirectoryPath: String?) {
+    public init(projectDirectoryPath: String) {
         self.projectDirectoryPath = projectDirectoryPath
     }
 
     public func updateScript(withName scriptName: String,
                              format: Format,
-                             targetName: String?,
+                             targetName: String,
                              projectNames: [String],
                              frameworksDirectoryPath: String,
                              shouldAppend: Bool) throws {
@@ -59,7 +59,7 @@ public final class ProjectService {
 
     public func updateScript(withName scriptName: String,
                              format: Format,
-                             targetName: String?,
+                             targetName: String,
                              projectPath: String,
                              frameworksDirectoryPaths: [String],
                              shouldAppend: Bool) throws {
@@ -75,7 +75,7 @@ public final class ProjectService {
 
     public func updateScript(withName scriptName: String,
                              format: Format,
-                             targetName: String?,
+                             targetName: String,
                              projectPath: String,
                              frameworksDirectoryPath: String,
                              shouldAppend: Bool) throws {
@@ -182,7 +182,7 @@ public final class ProjectService {
 
     public func lintScript(withName scriptName: String,
                            format: Format,
-                           targetName: String?,
+                           targetName: String,
                            projectNames: [String],
                            frameworksDirectoryPath: String) throws {
         let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: projectNames)
@@ -201,7 +201,7 @@ public final class ProjectService {
 
     public func lintScript(withName scriptName: String,
                            format: Format,
-                           targetName: String?,
+                           targetName: String,
                            projectPath: String,
                            frameworksDirectoryPaths: [String]) throws {
         for path in frameworksDirectoryPaths {
@@ -215,7 +215,7 @@ public final class ProjectService {
 
     public func lintScript(withName scriptName: String,
                            format: Format,
-                           targetName: String?,
+                           targetName: String,
                            projectPath: String,
                            frameworksDirectoryPath: String) throws {
         let xcodeproj = try XcodeProj(pathString: projectPath)
@@ -293,10 +293,10 @@ public final class ProjectService {
         targetName + "-outputPaths.xcfilelist"
     }
 
-    private func targets(in project: XcodeProj, withName name: String?) throws -> [PBXNativeTarget] {
+    private func targets(in project: XcodeProj, withName name: String) throws -> [PBXNativeTarget] {
         let filteredTargets = project.targets(with: .application, name: name)
 
-        if let name = name, filteredTargets.isEmpty {
+        if !name.isEmpty, filteredTargets.isEmpty {
             throw Error.targetFilterFailed(name: name)
         }
 

--- a/Sources/CartingCore/Services/ProjectService.swift
+++ b/Sources/CartingCore/Services/ProjectService.swift
@@ -60,9 +60,13 @@ public final class ProjectService {
     public func updateScript(withName scriptName: String,
                              format: Format,
                              targetName: String,
-                             projectPath: String,
                              frameworksDirectoryPaths: [String],
                              shouldAppend: Bool) throws {
+        let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: [])
+        guard let projectPath = projectPaths.first else {
+            print(Constants.nothingToUpdate)
+            return
+        }
         for path in frameworksDirectoryPaths {
             try updateScript(withName: scriptName,
                              format: format,
@@ -202,8 +206,12 @@ public final class ProjectService {
     public func lintScript(withName scriptName: String,
                            format: Format,
                            targetName: String,
-                           projectPath: String,
                            frameworksDirectoryPaths: [String]) throws {
+        let projectPaths = try self.projectPaths(inDirectory: projectDirectoryPath, filterNames: [])
+        guard let projectPath = projectPaths.first else {
+            print("🤷‍♂️ Nothing to lint.")
+            return
+        }
         for path in frameworksDirectoryPaths {
             try lintScript(withName: scriptName,
                            format: format,

--- a/Sources/CartingCore/Services/ProjectServiceContext.swift
+++ b/Sources/CartingCore/Services/ProjectServiceContext.swift
@@ -1,0 +1,30 @@
+//
+//
+
+import Foundation
+
+extension ProjectService {
+    public struct Context {
+        public init(scriptName: String,
+                    projectPath: String,
+                    format: Format,
+                    target: String,
+                    projectNames: [String],
+                    frameworksDirectoryNames: [String]) {
+            self.scriptName = scriptName
+            self.projectPath = projectPath
+            self.format = format
+            self.target = target
+            self.projectNames = projectNames
+            self.frameworksDirectoryNames = frameworksDirectoryNames
+        }
+
+        let scriptName: String
+        let projectPath: String
+        let format: Format
+        let target: String
+        let projectNames: [String]
+        let frameworksDirectoryNames: [String]
+    }
+}
+


### PR DESCRIPTION
Unlink Carting from Carthage project directory:
1. Add option to define multiple paths, where Carting will search frameworks to proceed
2. Store `carting update` output files in project directory (not `Carthage/` directory)

> such functionality is required for using Carting not only for Carthage-installed frameworks, but for "any other dependency manager"-installed frameworks